### PR TITLE
Resolve '419 page expired' issue

### DIFF
--- a/resources/views/app/settings/transactionalMailConfiguration/sendTestMail.blade.php
+++ b/resources/views/app/settings/transactionalMailConfiguration/sendTestMail.blade.php
@@ -13,6 +13,7 @@
     @if ($mailConfiguration->isValid())
 
     <form class="flex items-end justify-start" method="POST">
+        @csrf
         <div class="flex-grow max-w-lg">
             <x-mailcoach::text-field :placeholder="__('From Email')" :label="__('From Email')" name="from_email" type="email" :value="auth()->user()->email"/>
         </div>


### PR DESCRIPTION
Add csrf field to sendTestMail view form.
This resolves the issue where a `419 page expired` response is sent 
when trying to send a test transactional email.