### PR TITLE
Fixed EN typo

### DIFF
--- a/resources/views/app/account/tokens.blade.php
+++ b/resources/views/app/account/tokens.blade.php
@@ -37,7 +37,7 @@
         @push('modals')
             <x-mailcoach::modal :open="true" :title="__('Your new token')" name="token">
                 <p data-confirm-modal-text class="mb-2">
-                    We will display this token only once. Make sure to copy it to a save place.
+                    We will display this token only once. Make sure to copy it to a safe place.
                 </p>
 
 


### PR DESCRIPTION
It should be "safe place" instead of "save place", no?