### PR TITLE
Do not forcibly change a disk url

### DIFF
--- a/src/Support/AppConfiguration/AppConfiguration.php
+++ b/src/Support/AppConfiguration/AppConfiguration.php
@@ -42,7 +42,7 @@ class AppConfiguration
         config()->set('app.name', $this->valuestore->get('name', config('app.name')));
         config()->set('app.timezone', $this->valuestore->get('timezone', config('app.timezone')));
         config()->set('app.url', $this->valuestore->get('url', config('app.url')));
-        config()->set('filesystems.disks.public.url', $this->valuestore->get('url', config('app.url')) . '/storage');
+        config()->set('filesystems.disks.public.url', $this->valuestore->get('url', config('app.url')));
 
         ConfigCache::clear();
     }


### PR DESCRIPTION
This bug caused us (me) quite a headache. You're forcibly overwriting our requested URL throughout the app (not just in Mailcoach).

We don't use the `/storage` prefix for our URLs, however after simply installing Mailcoach it is now absolutely impossible to get rid of.
If people want `/storage` in their URL, they should just use the option for it, which is default in Laravel anyways. https://github.com/laravel/laravel/blob/10.x/config/filesystems.php#L42

<img width="989" alt="image" src="https://user-images.githubusercontent.com/2234034/228798728-949b1d24-8a5b-4f9c-9475-e49415e82330.png">


